### PR TITLE
Feature/20 dev gRPC

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -38,7 +38,6 @@ object Dependencies {
     const val GRPC_KOTLIN_STUB = "io.grpc:grpc-kotlin-stub:${DependencyVersion.GRPC_KOTLIN}"
     const val PROTOBUF_KOTLIN = "com.google.protobuf:protobuf-kotlin:${DependencyVersion.PROTOBUF}"
     const val GRPC_TESTING = "io.grpc:grpc-testing:${DependencyVersion.GRPC}"
-    const val GRPC_SERVER = "net.devh:grpc-server-spring-boot-starter:${DependencyVersion.GRPC_SERVER}"
     const val GRPC_CLIENT = "net.devh:grpc-client-spring-boot-starter:${DependencyVersion.GRPC_CLIENT}"
     const val GOOGLE_PROTOBUF = "com.google.protobuf:protobuf-java:${DependencyVersion.GOOGLE_PROTOBUF}"
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -42,6 +42,9 @@ object Dependencies {
     const val GRPC_CLIENT = "net.devh:grpc-client-spring-boot-starter:${DependencyVersion.GRPC_CLIENT}"
     const val GOOGLE_PROTOBUF = "com.google.protobuf:protobuf-java:${DependencyVersion.GOOGLE_PROTOBUF}"
 
+    // coroutines
+    const val COROUTINES = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${DependencyVersion.COROUTINES}"
+
     // swagger
     const val SWAGGER = "org.springdoc:springdoc-openapi-starter-webmvc-ui:${DependencyVersion.SWAGGER_VERSION}"
 

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -38,7 +38,9 @@ object Dependencies {
     const val GRPC_KOTLIN_STUB = "io.grpc:grpc-kotlin-stub:${DependencyVersion.GRPC_KOTLIN}"
     const val PROTOBUF_KOTLIN = "com.google.protobuf:protobuf-kotlin:${DependencyVersion.PROTOBUF}"
     const val GRPC_TESTING = "io.grpc:grpc-testing:${DependencyVersion.GRPC}"
-
+    const val GRPC_SERVER = "net.devh:grpc-server-spring-boot-starter:${DependencyVersion.GRPC_SERVER}"
+    const val GRPC_CLIENT = "net.devh:grpc-client-spring-boot-starter:${DependencyVersion.GRPC_CLIENT}"
+    const val GOOGLE_PROTOBUF = "com.google.protobuf:protobuf-java:${DependencyVersion.GOGGLE_PROTOBUF}"
 
     // swagger
     const val SWAGGER = "org.springdoc:springdoc-openapi-starter-webmvc-ui:${DependencyVersion.SWAGGER_VERSION}"

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -40,7 +40,7 @@ object Dependencies {
     const val GRPC_TESTING = "io.grpc:grpc-testing:${DependencyVersion.GRPC}"
     const val GRPC_SERVER = "net.devh:grpc-server-spring-boot-starter:${DependencyVersion.GRPC_SERVER}"
     const val GRPC_CLIENT = "net.devh:grpc-client-spring-boot-starter:${DependencyVersion.GRPC_CLIENT}"
-    const val GOOGLE_PROTOBUF = "com.google.protobuf:protobuf-java:${DependencyVersion.GOGGLE_PROTOBUF}"
+    const val GOOGLE_PROTOBUF = "com.google.protobuf:protobuf-java:${DependencyVersion.GOOGLE_PROTOBUF}"
 
     // swagger
     const val SWAGGER = "org.springdoc:springdoc-openapi-starter-webmvc-ui:${DependencyVersion.SWAGGER_VERSION}"

--- a/buildSrc/src/main/kotlin/DependencyVersion.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersion.kt
@@ -12,6 +12,9 @@ object DependencyVersion {
     const val GRPC = "1.61.1"
     const val GRPC_KOTLIN = "1.4.1"
     const val PROTOBUF = "3.25.3"
+    const val GRPC_SERVER = "2.15.0.RELEASE"
+    const val GRPC_CLIENT = "2.15.0.RELEASE"
+    const val GOGGLE_PROTOBUF = "3.25.3"
 
     const val SWAGGER_VERSION = "2.5.0"
     const val AWS = "1.12.281"

--- a/buildSrc/src/main/kotlin/DependencyVersion.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersion.kt
@@ -4,6 +4,7 @@ object DependencyVersion {
     const val SPRING_DEPENDENCY_MANAGEMENT = "1.1.7"
     const val DETEKT = "1.23.6"
     const val KTLINT = "12.1.1"
+    const val COROUTINES = "1.8.0"
 
     const val JWT = "0.11.5"
     const val ORG_JSON = "20230227"

--- a/buildSrc/src/main/kotlin/DependencyVersion.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersion.kt
@@ -14,7 +14,7 @@ object DependencyVersion {
     const val PROTOBUF = "3.25.3"
     const val GRPC_SERVER = "2.15.0.RELEASE"
     const val GRPC_CLIENT = "2.15.0.RELEASE"
-    const val GOGGLE_PROTOBUF = "3.25.3"
+    const val GOOGLE_PROTOBUF = "3.25.3"
 
     const val SWAGGER_VERSION = "2.5.0"
     const val AWS = "1.12.281"

--- a/buildSrc/src/main/kotlin/DependencyVersion.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersion.kt
@@ -13,7 +13,6 @@ object DependencyVersion {
     const val GRPC = "1.61.1"
     const val GRPC_KOTLIN = "1.4.1"
     const val PROTOBUF = "3.25.3"
-    const val GRPC_SERVER = "2.15.0.RELEASE"
     const val GRPC_CLIENT = "2.15.0.RELEASE"
     const val GOOGLE_PROTOBUF = "3.25.3"
 

--- a/buildSrc/src/main/kotlin/PluginVersion.kt
+++ b/buildSrc/src/main/kotlin/PluginVersion.kt
@@ -1,5 +1,5 @@
 object PluginVersion {
-    const val KOTLIN_VERSION = "1.9.25"
+    const val KOTLIN_VERSION = "1.9.23"
     const val SPRING_BOOT_VERSION = "3.4.4"
     const val SPRING_DEPENDENCY_MANAGEMENT_VERSION = "1.1.7"
     const val DETEKT_VERSION = "1.23.6"

--- a/casper-feed/build.gradle.kts
+++ b/casper-feed/build.gradle.kts
@@ -70,9 +70,11 @@ dependencies {
     implementation(Dependencies.GRPC_KOTLIN_STUB)
     implementation(Dependencies.PROTOBUF_KOTLIN)
     testImplementation(Dependencies.GRPC_TESTING)
-    implementation(Dependencies.GRPC_SERVER)
     implementation(Dependencies.GRPC_CLIENT)
     implementation(Dependencies.GOOGLE_PROTOBUF)
+
+    // 코루틴
+    implementation(Dependencies.COROUTINES)
 
     // swagger
     implementation(Dependencies.SWAGGER)

--- a/casper-feed/build.gradle.kts
+++ b/casper-feed/build.gradle.kts
@@ -1,0 +1,126 @@
+plugins {
+    id(Plugin.KOTLIN_JVM) version PluginVersion.KOTLIN_VERSION
+    id(Plugin.KOTLIN_SPRING) version PluginVersion.KOTLIN_VERSION
+    id(Plugin.KOTLIN_KAPT)
+    id(Plugin.SPRING_BOOT) version PluginVersion.SPRING_BOOT_VERSION
+    id(Plugin.SPRING_DEPENDENCY_MANAGEMENT) version PluginVersion.SPRING_DEPENDENCY_MANAGEMENT_VERSION
+    id(Plugin.CASPER_DOCUMENTATION)
+    id(Plugin.PROTOBUF) version PluginVersion.PROTOBUF_VERSION
+}
+
+group = "hs.kr.entrydsm"
+version = "0.0.1-SNAPSHOT"
+
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(17)
+	}
+}
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+    // 스프링 부트 기본 기능
+    implementation(Dependencies.SPRING_BOOT_STARTER)
+
+    // 코틀린 리플렉션
+    implementation(Dependencies.KOTLIN_REFLECT)
+
+    // 스프링 부트 테스트 도구
+    testImplementation(Dependencies.SPRING_BOOT_STARTER_TEST)
+
+    // 코틀린 + JUnit5 테스트
+    testImplementation(Dependencies.KOTLIN_TEST_JUNIT5)
+
+    // JUnit5 실행 런처
+    testRuntimeOnly(Dependencies.JUNIT_PLATFORM_LAUNCHER)
+
+    // 웹 관련
+    implementation(Dependencies.SPRING_BOOT_STARTER_WEB)
+
+    // 데이터베이스
+    implementation(Dependencies.SPRING_BOOT_STARTER_DATA_JPA)
+    implementation(Dependencies.SPRING_BOOT_STARTER_DATA_REDIS)
+    runtimeOnly(Dependencies.MYSQL_CONNECTOR)
+
+    // 보안
+    implementation(Dependencies.SPRING_BOOT_STARTER_SECURITY)
+
+    // 검증
+    implementation(Dependencies.SPRING_BOOT_STARTER_VALIDATION)
+
+    // JSON 처리
+    implementation(Dependencies.JACKSON_MODULE_KOTLIN)
+    implementation(Dependencies.ORG_JSON)
+
+    // JWT
+    implementation(Dependencies.JWT_API)
+    implementation(Dependencies.JWT_IMPL)
+    runtimeOnly(Dependencies.JWT_JACKSON)
+
+    implementation(Dependencies.MAPSTRUCT)
+    kapt(Dependencies.MAPSTRUCT_PROCESSOR)
+
+    // grpc
+    implementation(Dependencies.GRPC_NETTY_SHADED)
+    implementation(Dependencies.GRPC_PROTOBUF)
+    implementation(Dependencies.GRPC_STUB)
+    implementation(Dependencies.GRPC_KOTLIN_STUB)
+    implementation(Dependencies.PROTOBUF_KOTLIN)
+    testImplementation(Dependencies.GRPC_TESTING)
+    implementation(Dependencies.GRPC_SERVER)
+    implementation(Dependencies.GRPC_CLIENT)
+    implementation(Dependencies.GOOGLE_PROTOBUF)
+
+    // swagger
+    implementation(Dependencies.SWAGGER)
+
+    // aws
+    implementation(Dependencies.AWS)
+
+    // feign
+    implementation(Dependencies.OPEN_FEIGN)
+
+    // Kafka
+    implementation(Dependencies.KAFKA)
+    implementation("org.springframework.kafka:spring-kafka:3.1.2")
+
+    // Cloud Config
+    // implementation(Dependencies.CLOUD_CONFIG)
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:${DependencyVersion.PROTOBUF}"
+    }
+    plugins {
+        create("grpc") {
+            artifact = "io.grpc:protoc-gen-grpc-java:${DependencyVersion.GRPC}"
+        }
+        create("grpckt") {
+            artifact = "io.grpc:protoc-gen-grpc-kotlin:${DependencyVersion.GRPC_KOTLIN}:jdk8@jar"
+        }
+    }
+    generateProtoTasks {
+        all().forEach {
+            it.plugins {
+                create("grpc")
+                create("grpckt")
+            }
+        }
+
+    }
+
+}
+
+kotlin {
+	compilerOptions {
+		freeCompilerArgs.addAll("-Xjsr305=strict")
+	}
+}
+
+tasks.withType<Test> {
+	useJUnitPlatform()
+}

--- a/casper-feed/src/main/kotlin/hs/kr/entrydsm/feed/infrastructure/grpc/client/AdminGrpcClient.kt
+++ b/casper-feed/src/main/kotlin/hs/kr/entrydsm/feed/infrastructure/grpc/client/AdminGrpcClient.kt
@@ -4,9 +4,13 @@ import hs.kr.entrydsm.casper.admin.proto.AdminServiceGrpc
 import hs.kr.entrydsm.casper.admin.proto.AdminServiceProto
 import hs.kr.entrydsm.feed.infrastructure.grpc.client.dto.response.InternalAdminResponse
 import io.grpc.Channel
+import io.grpc.stub.StreamObserver
+import kotlinx.coroutines.suspendCancellableCoroutine
 import net.devh.boot.grpc.client.inject.GrpcClient
 import org.springframework.stereotype.Component
 import java.util.UUID
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
  * 관리자 서비스와의 gRPC 통신을 담당하는 클라이언트 클래스입니다.
@@ -19,20 +23,34 @@ class AdminGrpcClient {
     @GrpcClient("user-service")
     lateinit var channel: Channel
 
+
     /**
-     * 관리자 ID를 기반으로 관리자 정보를 조회합니다.
+     * 관리자 ID를 기반으로 관리자 정보를 비동기적으로 조회합니다.
+     * gRPC 비동기 스트리밍을 사용하여 관리자 서비스로부터 정보를 가져옵니다.
      *
      * @param adminId 조회할 관리자의 고유 식별자(UUID)
      * @return 조회된 관리자 정보를 담은 [InternalAdminResponse] 객체
-     * @throws io.grpc.StatusRuntimeException gRPC 통신 중 오류가 발생한 경우
+     * @throws io.grpc.StatusRuntimeException gRPC 서버에서 오류가 발생한 경우
+     * @throws java.util.concurrent.CancellationException 코루틴이 취소된 경우
      */
     suspend fun getAdminInfoByAdminId(adminId: UUID): InternalAdminResponse {
-        val adminStub = AdminServiceGrpc.newBlockingStub(channel)
+        val adminStub = AdminServiceGrpc.newStub(channel)
 
         val request = AdminServiceProto.GetAdminIdRequest.newBuilder()
             .setAdminId(adminId.toString())
             .build()
-        val response = adminStub.getAdminByUUID(request)
+
+        val response = suspendCancellableCoroutine { continuation ->
+            adminStub.getAdminByUUID(request, object : StreamObserver<AdminServiceProto.GetAdminIdResponse> {
+                override fun onNext(value: AdminServiceProto.GetAdminIdResponse) {
+                    continuation.resume(value)
+                }
+                override fun onError(t: Throwable) {
+                    continuation.resumeWithException(t)
+                }
+                override fun onCompleted() {}
+            })
+        }
 
         return InternalAdminResponse(id = UUID.fromString(response.adminId))
     }

--- a/casper-feed/src/main/kotlin/hs/kr/entrydsm/feed/infrastructure/grpc/client/AdminGrpcClient.kt
+++ b/casper-feed/src/main/kotlin/hs/kr/entrydsm/feed/infrastructure/grpc/client/AdminGrpcClient.kt
@@ -1,0 +1,39 @@
+package hs.kr.entrydsm.feed.infrastructure.grpc.client
+
+import hs.kr.entrydsm.casper.admin.proto.AdminServiceGrpc
+import hs.kr.entrydsm.casper.admin.proto.AdminServiceProto
+import hs.kr.entrydsm.feed.infrastructure.grpc.client.dto.response.InternalAdminResponse
+import io.grpc.Channel
+import net.devh.boot.grpc.client.inject.GrpcClient
+import org.springframework.stereotype.Component
+import java.util.UUID
+
+/**
+ * 관리자 서비스와의 gRPC 통신을 담당하는 클라이언트 클래스입니다.
+ *
+ * @property channel gRPC 통신을 위한 채널 (user-service로 자동 주입됨)
+ */
+@Component
+class AdminGrpcClient {
+
+    @GrpcClient("user-service")
+    lateinit var channel: Channel
+
+    /**
+     * 관리자 ID를 기반으로 관리자 정보를 조회합니다.
+     *
+     * @param adminId 조회할 관리자의 고유 식별자(UUID)
+     * @return 조회된 관리자 정보를 담은 [InternalAdminResponse] 객체
+     * @throws io.grpc.StatusRuntimeException gRPC 통신 중 오류가 발생한 경우
+     */
+    suspend fun getAdminInfoByAdminId(adminId: UUID): InternalAdminResponse {
+        val adminStub = AdminServiceGrpc.newBlockingStub(channel)
+
+        val request = AdminServiceProto.GetAdminIdRequest.newBuilder()
+            .setAdminId(adminId.toString())
+            .build()
+        val response = adminStub.getAdminByUUID(request)
+
+        return InternalAdminResponse(id = UUID.fromString(response.adminId))
+    }
+}

--- a/casper-feed/src/main/kotlin/hs/kr/entrydsm/feed/infrastructure/grpc/client/AdminGrpcClient.kt
+++ b/casper-feed/src/main/kotlin/hs/kr/entrydsm/feed/infrastructure/grpc/client/AdminGrpcClient.kt
@@ -23,7 +23,6 @@ class AdminGrpcClient {
     @GrpcClient("user-service")
     lateinit var channel: Channel
 
-
     /**
      * 관리자 ID를 기반으로 관리자 정보를 비동기적으로 조회합니다.
      * gRPC 비동기 스트리밍을 사용하여 관리자 서비스로부터 정보를 가져옵니다.

--- a/casper-feed/src/main/kotlin/hs/kr/entrydsm/feed/infrastructure/grpc/client/dto/response/InternalAdminResponse.kt
+++ b/casper-feed/src/main/kotlin/hs/kr/entrydsm/feed/infrastructure/grpc/client/dto/response/InternalAdminResponse.kt
@@ -1,0 +1,12 @@
+package hs.kr.entrydsm.feed.infrastructure.grpc.client.dto.response
+
+import java.util.UUID
+
+/**
+ * 관리자 정보를 담는 데이터 클래스입니다.
+ *
+ * @property id 관리자의 고유 식별자(UUID)
+ */
+data class InternalAdminResponse(
+    val id: UUID
+)

--- a/casper-feed/src/main/proto/admin.proto
+++ b/casper-feed/src/main/proto/admin.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package admin.proto;
+
+option java_package = "hs.kr.entrydsm.casper.admin.proto";
+option java_outer_classname = "AdminServiceProto";
+
+service AdminService {
+    rpc GetAdminByUUID(GetAdminIdRequest) returns (GetAdminIdResponse);
+}
+
+message GetAdminIdRequest {
+    string admin_id =1;
+}
+
+message GetAdminIdResponse{
+    string admin_id = 1;
+}

--- a/casper-feed/src/main/proto/admin.proto
+++ b/casper-feed/src/main/proto/admin.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package admin.proto;
+package casper.feed;
 
 option java_package = "hs.kr.entrydsm.casper.admin.proto";
 option java_outer_classname = "AdminServiceProto";

--- a/casper-feed/src/test/kotlin/hs/kr/entrydsm/feed/CasperFeedApplicationTests.kt
+++ b/casper-feed/src/test/kotlin/hs/kr/entrydsm/feed/CasperFeedApplicationTests.kt
@@ -1,0 +1,26 @@
+package hs.kr.entrydsm.feed
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+/**
+ * Casper Feed 애플리케이션의 통합 테스트 클래스입니다.
+ *
+ * 이 클래스는 Spring 애플리케이션 컨텍스트가 모든 필요한 빈과 설정과 함께
+ * 성공적으로 로드되는지 검증합니다.
+ */
+@SpringBootTest(classes = [CasperFeedApplication::class])
+class CasperFeedApplicationTests {
+
+    /**
+     * 애플리케이션 컨텍스트가 성공적으로 로드되는지 테스트합니다.
+     *
+     * 이 테스트는 Spring 애플리케이션 컨텍스트가 모든 필요한 설정과 빈이 제대로
+     * 초기화된 상태로 시작될 수 있는지 확인합니다.
+     * 컨텍스트 로딩에 실패할 경우 이 테스트는 실패합니다.
+     */
+    @Test
+    fun contextLoads() {
+        // 애플리케이션 컨텍스트가 성공적으로 로드되면 테스트가 통과합니다.
+    }
+}

--- a/detekt.yml
+++ b/detekt.yml
@@ -1,7 +1,7 @@
 complexity:
   active: true
   LongParameterList:
-    active: true
+    active: false
     functionThreshold: 6
     constructorThreshold: 7
 
@@ -11,7 +11,7 @@ style:
     active: true
     maxLineLength: 120
   MagicNumber:
-    active: true
+    active: false
     ignoreNumbers:
       - '-1'
       - '0'


### PR DESCRIPTION
# 📌 개요
- 관리자 ID(UUID)를 기반으로 내부 관리자 정보를 조회할 수 있는 gRPC 클라이언트를 구현했습니다.
- 서비스 간 통신의 효율성과 타입 안정성을 확보하기 위해 CoroutineStub 기반의 gRPC 호출 방식을 사용했습니다.
- 누락된 커밋들과 gRPC 관련 의존성을 추가하였습니다.

## 🧩 주요 변경 사항
### ✅ 기능 구현
- AdminGrpcClient 클래스 생성

- getAdminInfoByAdminId(UUID): InternalAdminResponse 메서드 구현

- CoroutineStub을 사용한 비동기 gRPC 호출

- InternalAdminResponse DTO 생성

- gRPC 응답 데이터를 도메인 내부에서 사용할 수 있도록 변환

- admin.proto 정의

- GetAdminByUUID RPC 메서드 및 관련 메시지 정의



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * gRPC 기반 외부 관리자 서비스 연동을 위한 클라이언트 및 데이터 응답 클래스가 추가되었습니다.
  * 관리자 정보를 조회하는 gRPC 서비스 및 프로토콜 정의가 도입되었습니다.
  * 신규 Gradle 빌드 스크립트가 추가되어 다양한 의존성과 플러그인, 프로토콜 버퍼 설정이 적용되었습니다.

* **Bug Fixes**
  * 없음

* **Tests**
  * 애플리케이션 컨텍스트 로드 여부를 확인하는 통합 테스트가 추가되었습니다.

* **Chores**
  * gRPC, Protobuf 등 관련 라이브러리 및 버전 상수가 추가되었습니다.
  * Kotlin 플러그인 버전이 변경되었습니다.
  * 코드 스타일 검사에서 복잡성 및 매직 넘버 규칙이 비활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->