### PR TITLE
Feature/22 spring cloud config setting

### DIFF
--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -54,5 +54,8 @@ object Dependencies {
     const val OPEN_FEIGN = "org.springframework.cloud:spring-cloud-starter-openfeign:${DependencyVersion.OPEN_FEIGN_VERSION}"
 
     // Kafka
-    const val KAFKA = "org.springframework.kafka:spring-kafka"
+    const val KAFKA = "org.springframework.kafka:spring-kafka:${DependencyVersion.KAFKA_VERSION}"
+
+    // Spring Cloud Config
+    const val SPRING_CLOUD_CONFIG = "org.springframework.cloud:spring-cloud-starter-config"
 }

--- a/buildSrc/src/main/kotlin/DependencyVersion.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersion.kt
@@ -16,8 +16,12 @@ object DependencyVersion {
     const val GRPC_CLIENT = "2.15.0.RELEASE"
     const val GOOGLE_PROTOBUF = "3.25.3"
 
+    const val KAFKA_VERSION = "3.1.2"
+
     const val SWAGGER_VERSION = "2.5.0"
     const val AWS = "1.12.281"
 
     const val OPEN_FEIGN_VERSION = "3.1.4"
+
+    const val SPRING_CLOUD_CONFIG_VERSION = "2023.0.3"
 }

--- a/casper-feed/build.gradle.kts
+++ b/casper-feed/build.gradle.kts
@@ -21,6 +21,12 @@ repositories {
 	mavenCentral()
 }
 
+dependencyManagement {
+    imports {
+        mavenBom("org.springframework.cloud:spring-cloud-dependencies:${DependencyVersion.SPRING_CLOUD_CONFIG_VERSION}")
+    }
+}
+
 dependencies {
     // 스프링 부트 기본 기능
     implementation(Dependencies.SPRING_BOOT_STARTER)
@@ -87,10 +93,9 @@ dependencies {
 
     // Kafka
     implementation(Dependencies.KAFKA)
-    implementation("org.springframework.kafka:spring-kafka:3.1.2")
 
     // Cloud Config
-    // implementation(Dependencies.CLOUD_CONFIG)
+    implementation(Dependencies.SPRING_CLOUD_CONFIG)
 }
 
 protobuf {

--- a/casper-feed/src/main/resources/application.yml
+++ b/casper-feed/src/main/resources/application.yml
@@ -1,0 +1,22 @@
+spring:
+    application:
+        name: Casper-Feed
+    config:
+        import: "configserver:${CONFIG_SERVER_URL}"
+    cloud:
+        config:
+            label: main
+            fail-fast: true
+            retry:
+                initial-interval: 1000
+                max-attempts: 6
+                max-interval: 2000
+                multiplier: 1.1
+    profiles:
+        active: ${SPRING_PROFILES_ACTIVE}
+
+management:
+    endpoints:
+        web:
+            exposure:
+                include: health,info,refresh


### PR DESCRIPTION
- spring cloud config 의존성을 추가하고 다음과 같이 spring cloud config을 설정하였습니다.

`application.yml`
```
spring:
    application:
        name: Casper-Feed
    config:
        import: "configserver:${CONFIG_SERVER_URL}"
    cloud:
        config:
            label: main
            fail-fast: true
            retry:
                initial-interval: 1000
                max-attempts: 6
                max-interval: 2000
                multiplier: 1.1
    profiles:
        active: ${SPRING_PROFILES_ACTIVE}

management:
    endpoints:
        web:
            exposure:
                include: health,info,refresh

```